### PR TITLE
feat: add support for sqlalchemy 2.0

### DIFF
--- a/rdbbeat/db/migrations/env.py
+++ b/rdbbeat/db/migrations/env.py
@@ -1,7 +1,7 @@
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 
 from rdbbeat.db.models import Base
 from rdbbeat.settings import DATABASE_URL
@@ -70,7 +70,7 @@ def run_migrations_online():
 
         # First ensure we have our scheduler schema available as all of these migrations will live
         # within this schema.
-        connection.execute("CREATE SCHEMA IF NOT EXISTS scheduler")
+        connection.execute(text("CREATE SCHEMA IF NOT EXISTS scheduler"))
 
         with context.begin_transaction():
             context.run_migrations()

--- a/rdbbeat/db/models.py
+++ b/rdbbeat/db/models.py
@@ -12,7 +12,7 @@ from celery import schedules
 from sqlalchemy import MetaData, func
 from sqlalchemy.engine import Engine
 from sqlalchemy.event import listen
-from sqlalchemy.orm import Session, class_mapper, foreign, relationship, remote, declarative_base
+from sqlalchemy.orm import Session, class_mapper, declarative_base, foreign, relationship, remote
 from sqlalchemy.sql import insert, select, update
 
 from rdbbeat.tzcrontab import TzAwareCrontab

--- a/rdbbeat/db/models.py
+++ b/rdbbeat/db/models.py
@@ -12,8 +12,7 @@ from celery import schedules
 from sqlalchemy import MetaData, func
 from sqlalchemy.engine import Engine
 from sqlalchemy.event import listen
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session, class_mapper, foreign, relationship, remote
+from sqlalchemy.orm import Session, class_mapper, foreign, relationship, remote, declarative_base
 from sqlalchemy.sql import insert, select, update
 
 from rdbbeat.tzcrontab import TzAwareCrontab

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "celery~=5.2",
-        "sqlalchemy~=1.4",
+        "sqlalchemy",
         "alembic",
         "pydantic",
         "python-dotenv",


### PR DESCRIPTION
## Description

Right now rdbbeat does not work with SqlAlchemy 2.0, which limits the version of other libraries in use around it. This opens up the allowed versions during install

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (`fix`): A non-breaking change which fixes an issue or bug
- [x] New Feature (`feat`): A non-breaking change which adds a new feature or new functionality
- [ ] Tests (`test`): Adding missing tests or correcting existing tests
- [ ] Refactoring (`refactor`): A code change that neither fixes a bug nor adds a feature, e.g Deleting unused or redundant code
- [ ] Documentation (`docs`): Documentation only changes
- [ ] Other (`style`, `build`, `ci`, `performance`): Formatting, linting or styling. Changes to the CI pipeline. Performance improvements. Changes that affect the build system.

## Further Information

Any relevant logs, screenshots, testing output, etc...
