### PR TITLE
fix: don't disable schedule on exception

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 message = Bump version: {current_version} → {new_version}
 tag = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0
 commit = True
 message = Bump version: {current_version} → {new_version}
 tag = False

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change history
 
+## v0.2.1
+
+- Do not automatically disable a schedule when an error occurs on initialisation of a `ModelEntry`
+
 ## v0.2.0
 
 - Add support for `SQLAlchemy 2.0` PR #35 by @pattertj

--- a/rdbbeat/schedulers.py
+++ b/rdbbeat/schedulers.py
@@ -61,7 +61,6 @@ class ModelEntry(ScheduleEntry):
                 "Disabling schedule %s that was removed from database",
                 self.name,
             )
-            self._disable(model)
 
         try:
             self.args = loads(model.args or "[]")
@@ -72,7 +71,6 @@ class ModelEntry(ScheduleEntry):
                 self.name,
                 exc,
             )
-            self._disable(model)
 
         self.options = {}
         for option in ["queue", "exchange", "routing_key", "expires", "priority"]:

--- a/rdbbeat/schedulers.py
+++ b/rdbbeat/schedulers.py
@@ -51,26 +51,11 @@ class ModelEntry(ScheduleEntry):
         self.model = model
         self.name = model.name
         self.task = model.task
+        self.schedule = model.schedule
+        self.args = loads(model.args or "[]")
+        self.kwargs = loads(model.kwargs or "{}")
 
-        try:
-            self.schedule = model.schedule
-            logger.debug(f"schedule: {self.schedule}")
-        except Exception as e:
-            logger.error(e)
-            logger.error(
-                "Disabling schedule %s that was removed from database",
-                self.name,
-            )
-
-        try:
-            self.args = loads(model.args or "[]")
-            self.kwargs = loads(model.kwargs or "{}")
-        except ValueError as exc:
-            logger.exception(
-                "Removing schedule %s for argument deseralization error: %r",
-                self.name,
-                exc,
-            )
+        logger.debug(f"schedule: {self.schedule}")
 
         self.options = {}
         for option in ["queue", "exchange", "routing_key", "expires", "priority"]:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name="rdbbeat",
     python_requires=">=3.8",
     author="Aruba UXI",
-    version="0.2.0",
+    version="0.2.1",
     description="A SQLAlchemy-based scheduler for celery-beat",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
To fix/circumvent the possible mass-disabling of schedules, do not automatically disable a schedule when a generic exception occurs. Proper logging and error handling should be done upstream from the scheduling library to raise awareness of encountered errors.